### PR TITLE
Add reports app skeleton

### DIFF
--- a/parkpass_backend/settings.py
+++ b/parkpass_backend/settings.py
@@ -139,6 +139,7 @@ INSTALLED_APPS = [
     'jwtauth',
     'rps_vendor',
     'owners',
+    'reports',
     'control',
     'partners',
     'fcm_django',

--- a/reports/__init__.py
+++ b/reports/__init__.py
@@ -1,0 +1,2 @@
+default_app_config = 'reports.apps.ReportsConfig'
+

--- a/reports/admin.py
+++ b/reports/admin.py
@@ -1,0 +1,19 @@
+from django.contrib import admin
+from .models import ReportObject, Transaction, Report
+
+
+@admin.register(ReportObject)
+class ReportObjectAdmin(admin.ModelAdmin):
+    list_display = ('name', 'company', 'commission', 'period_type', 'last_report_sent')
+
+
+@admin.register(Transaction)
+class TransactionAdmin(admin.ModelAdmin):
+    list_display = ('obj', 'datetime', 'amount', 'type', 'status')
+    list_filter = ('obj', 'type', 'status')
+
+
+@admin.register(Report)
+class ReportAdmin(admin.ModelAdmin):
+    list_display = ('obj', 'from_date', 'to_date', 'created_at', 'last_sent_at')
+    readonly_fields = ('created_at', 'total_income', 'total_refunds', 'total_commission', 'total_payout')

--- a/reports/apps.py
+++ b/reports/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class ReportsConfig(AppConfig):
+    name = 'reports'

--- a/reports/models.py
+++ b/reports/models.py
@@ -1,0 +1,91 @@
+from decimal import Decimal
+from django.db import models
+
+from base.validators import comma_separated_emails
+
+
+class ReportObject(models.Model):
+    company = models.ForeignKey('owners.Company', on_delete=models.CASCADE)
+    PERIOD_DAILY = 'daily'
+    PERIOD_WEEKLY = 'weekly'
+    PERIOD_MONTHLY = 'monthly'
+    PERIOD_N_DAYS = 'n_days'
+
+    PERIOD_CHOICES = [
+        (PERIOD_DAILY, 'Daily'),
+        (PERIOD_WEEKLY, 'Weekly'),
+        (PERIOD_MONTHLY, 'Monthly'),
+        (PERIOD_N_DAYS, 'Every N days'),
+    ]
+
+    name = models.CharField(max_length=255)
+    commission = models.DecimalField(max_digits=5, decimal_places=2, default=0)
+    inn = models.CharField(max_length=15, blank=True)
+    kpp = models.CharField(max_length=15, blank=True)
+    bic = models.CharField(max_length=20, blank=True)
+    account = models.CharField(max_length=64, blank=True)
+    recipient = models.CharField(max_length=255, blank=True)
+    period_type = models.CharField(max_length=16, choices=PERIOD_CHOICES, default=PERIOD_MONTHLY)
+    period_days = models.PositiveIntegerField(default=1)
+    report_emails = models.TextField(validators=[comma_separated_emails], blank=True)
+    send_without_confirmation = models.BooleanField(default=False)
+    last_report_sent = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        verbose_name = 'Reporting object'
+        verbose_name_plural = 'Reporting objects'
+
+    def __str__(self):
+        return self.name
+
+
+class Transaction(models.Model):
+    TYPE_SUCCESS = 'success'
+    TYPE_REFUND = 'refund'
+    TYPE_CHOICES = [
+        (TYPE_SUCCESS, 'Success'),
+        (TYPE_REFUND, 'Refund'),
+    ]
+
+    STATUS_CONFIRMED = 'CONFIRMED'
+    STATUS_CHOICES = [
+        (STATUS_CONFIRMED, 'Confirmed'),
+    ]
+
+    obj = models.ForeignKey(ReportObject, related_name='transactions', on_delete=models.CASCADE)
+    datetime = models.DateTimeField()
+    amount = models.DecimalField(max_digits=12, decimal_places=2)
+    type = models.CharField(max_length=20, choices=TYPE_CHOICES, default=TYPE_SUCCESS)
+    status = models.CharField(max_length=20, choices=STATUS_CHOICES, default=STATUS_CONFIRMED)
+
+    class Meta:
+        ordering = ['datetime']
+
+    def commission_amount(self):
+        if self.type == self.TYPE_SUCCESS:
+            return (self.amount * self.obj.commission / Decimal('100')).quantize(Decimal('0.01'))
+        return Decimal('0.00')
+
+    def payout_amount(self):
+        if self.type == self.TYPE_REFUND:
+            return -self.amount
+        return self.amount - self.commission_amount()
+
+
+class Report(models.Model):
+    obj = models.ForeignKey(ReportObject, related_name='reports', on_delete=models.CASCADE)
+    from_date = models.DateTimeField()
+    to_date = models.DateTimeField()
+    created_at = models.DateTimeField(auto_now_add=True)
+    file = models.FileField(upload_to='reports/', null=True, blank=True)
+    total_income = models.DecimalField(max_digits=12, decimal_places=2, default=0)
+    total_refunds = models.DecimalField(max_digits=12, decimal_places=2, default=0)
+    total_commission = models.DecimalField(max_digits=12, decimal_places=2, default=0)
+    total_payout = models.DecimalField(max_digits=12, decimal_places=2, default=0)
+    last_sent_at = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        ordering = ['-created_at']
+
+    def __str__(self):
+        return f'Report {self.obj} {self.from_date.date()}-{self.to_date.date()}'

--- a/reports/tasks.py
+++ b/reports/tasks.py
@@ -1,0 +1,28 @@
+from datetime import timedelta
+from django.utils import timezone
+from celery import shared_task
+
+from .models import ReportObject
+from .utils import create_report
+
+
+@shared_task
+def generate_periodic_reports():
+    now = timezone.now()
+    for obj in ReportObject.objects.all():
+        last = obj.last_report_sent or (now - timedelta(days=obj.period_days))
+        if obj.period_type == obj.PERIOD_DAILY:
+            step = timedelta(days=1)
+        elif obj.period_type == obj.PERIOD_WEEKLY:
+            step = timedelta(days=7)
+        elif obj.period_type == obj.PERIOD_MONTHLY:
+            step = timedelta(days=30)
+        else:
+            step = timedelta(days=obj.period_days)
+
+        if now - last >= step:
+            report = create_report(obj, last, now)
+            obj.last_report_sent = now
+            obj.save()
+            # sending logic can be implemented here
+            _ = report

--- a/reports/utils.py
+++ b/reports/utils.py
@@ -1,0 +1,107 @@
+import io
+from datetime import datetime
+from decimal import Decimal
+from typing import Iterable, List
+
+from openpyxl import Workbook
+
+from payments.models import (
+    TinkoffPayment,
+    PAYMENT_STATUS_CONFIRMED,
+    PAYMENT_STATUS_REFUNDED,
+    PAYMENT_STATUS_PARTIAL_REFUNDED,
+)
+
+from .models import Transaction, Report
+
+
+HEADER = [
+    'Date and time',
+    'Amount',
+    'Transaction type',
+    'Commission %',
+    'Amount to pay',
+]
+
+
+def generate_excel(report: Report, transactions: Iterable[Transaction]) -> bytes:
+    wb = Workbook()
+    ws = wb.active
+    ws.append(HEADER)
+
+    total_income = Decimal('0.00')
+    total_refunds = Decimal('0.00')
+    total_commission = Decimal('0.00')
+    total_payout = Decimal('0.00')
+
+    for tr in transactions:
+        commission_amount = tr.commission_amount()
+        payout = tr.payout_amount()
+        ws.append([
+            tr.datetime.strftime('%Y-%m-%d %H:%M'),
+            float(tr.amount) if tr.type == tr.TYPE_SUCCESS else -float(tr.amount),
+            'Refund' if tr.type == tr.TYPE_REFUND else 'Success',
+            float(report.obj.commission) if tr.type == tr.TYPE_SUCCESS else '',
+            float(payout),
+        ])
+        if tr.type == tr.TYPE_REFUND:
+            total_refunds += tr.amount
+            total_payout -= tr.amount
+        else:
+            total_income += tr.amount
+            total_commission += commission_amount
+            total_payout += payout
+
+    ws.append([])
+    ws.append(['Total income', float(total_income)])
+    ws.append(['Total refunds', float(total_refunds)])
+    ws.append(['Total commission', float(total_commission)])
+    ws.append(['Total payout', float(total_payout)])
+
+    buf = io.BytesIO()
+    wb.save(buf)
+    return buf.getvalue(), total_income, total_refunds, total_commission, total_payout
+
+
+def create_report(obj, from_date: datetime, to_date: datetime) -> Report:
+    payments = TinkoffPayment.objects.filter(
+        status__in=[
+            PAYMENT_STATUS_CONFIRMED,
+            PAYMENT_STATUS_REFUNDED,
+            PAYMENT_STATUS_PARTIAL_REFUNDED,
+        ],
+        updated_at__gte=from_date,
+        updated_at__lte=to_date,
+        order__session__parking__company=obj.company,
+    ).select_related('order').order_by('updated_at')
+
+    transactions: List[Transaction] = []
+    for pay in payments:
+        if pay.status in [PAYMENT_STATUS_REFUNDED, PAYMENT_STATUS_PARTIAL_REFUNDED]:
+            tr_type = Transaction.TYPE_REFUND
+            amount = pay.order.refunded_sum or pay.order.sum
+        else:
+            tr_type = Transaction.TYPE_SUCCESS
+            amount = pay.order.sum
+
+        tr = Transaction.objects.create(
+            obj=obj,
+            datetime=pay.updated_at,
+            amount=amount,
+            type=tr_type,
+            status=Transaction.STATUS_CONFIRMED,
+        )
+        transactions.append(tr)
+
+    report = Report.objects.create(obj=obj, from_date=from_date, to_date=to_date)
+    data, income, refunds, commission, payout = generate_excel(report, transactions)
+
+    report.total_income = income
+    report.total_refunds = refunds
+    report.total_commission = commission
+    report.total_payout = payout
+
+    filename = f'report_{report.id}.xlsx'
+    report.file.save(filename, io.BytesIO(data))
+    report.save()
+    return report

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -80,6 +80,7 @@ INSTALLED_APPS = [
     'jwtauth',
     'rps_vendor',
     'owners',
+    'reports',
     'control',
     'partners'
 ]


### PR DESCRIPTION
## Summary
- create `reports` Django app for generating transaction reports
- register app in settings
- stub out report models, admin, utilities, and tasks
- connect reports with Tinkoff payments

## Testing
- `python runtests.py` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685378ea0ef483258fb3c7aa41a69d06